### PR TITLE
ci: fix test workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set nightly flags (nightly only)
         if: ${{ matrix.version == 'nightly' }}
         run: |
-          echo "RUSTFLAGS=-Zinstrument-coverage" >> $GITHUB_ENV
+          echo "RUSTFLAGS=-Cinstrument-coverage" >> $GITHUB_ENV
           echo "LLVM_PROFILE_FILE=tasshi-me-%p-%m.profraw" >> $GITHUB_ENV
 
       - name: Rustup version


### PR DESCRIPTION
https://github.com/tasshi-me/fitting-rs/actions/runs/8002351698/job/21855369381

```
error: failed to run `rustc` to learn about target-specific information

Caused by:
  process didn't exit successfully: `/home/runner/.rustup/toolchains/nightly-x[8](https://github.com/tasshi-me/fitting-rs/actions/runs/8002351698/job/21855369381#step:12:9)6_64-unknown-linux-gnu/bin/rustc - --crate-name ___ --print=file-names -Zinstrument-coverage --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=split-debuginfo --print=crate-name --print=cfg` (exit status: 1)
  --- stderr
  error: unknown unstable option: `instrument-coverage`
```